### PR TITLE
Combine `wait()` methods into a new `poll()` method

### DIFF
--- a/examples/stdin.rs
+++ b/examples/stdin.rs
@@ -1,4 +1,4 @@
-use std::{io, io::prelude::*, process, time};
+use std::{io, io::prelude::*, process};
 
 use popol;
 
@@ -13,7 +13,7 @@ fn main() -> io::Result<()> {
 
     // Wait on our event sources for at most 6 seconds. If an event source is
     // ready before then, process its events. Otherwise, timeout.
-    match sources.wait_timeout(&mut events, time::Duration::from_secs(6)) {
+    match sources.poll(&mut events, popol::Timeout::from_secs(6)) {
         Ok(()) => {}
         Err(err) if err.kind() == io::ErrorKind::TimedOut => process::exit(1),
         Err(err) => return Err(err),

--- a/examples/tcp-listener.rs
+++ b/examples/tcp-listener.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io;
 use std::net;
 
-use popol::{Events, Sources};
+use popol::{Events, Sources, Timeout};
 
 /// The identifier we'll use with `popol` to figure out the source
 /// of an event.
@@ -28,7 +28,7 @@ fn main() -> io::Result<()> {
     sources.register(Source::Listener, &listener, popol::interest::READ);
 
     loop {
-        sources.wait(&mut events)?;
+        sources.poll(&mut events, Timeout::Never)?;
 
         for (key, event) in events.iter() {
             match key {

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::io::prelude::*;
 use std::net;
 
-use popol::{Events, Sources};
+use popol::{Events, Sources, Timeout};
 
 fn main() -> io::Result<()> {
     let mut stream = net::TcpStream::connect("localhost:8888").unwrap();
@@ -13,7 +13,7 @@ fn main() -> io::Result<()> {
     sources.register(stream.peer_addr()?, &stream, popol::interest::READ);
 
     loop {
-        sources.wait(&mut events)?;
+        sources.poll(&mut events, Timeout::Never)?;
 
         for (addr, event) in events.iter() {
             if event.readable {


### PR DESCRIPTION
Add a new, public `Sources::poll()` method that takes a value of the newly created `Timeout` enum with `Timeout::After(Duration)` and `Timeout::Never` variants.

Fix #4

---

I’ve tried to match your style as much as possible; please let me know if I‘ve messed anything up. Also, I‘m not sure if deprecating `wait()` and `wait_timeout()` is the best way to go about this, so let me know what you think.