### PR TITLE
Simplify Source and Event types

### DIFF
--- a/examples/stdin.rs
+++ b/examples/stdin.rs
@@ -23,11 +23,11 @@ fn main() -> io::Result<()> {
     // registered, this will only iterate once.
     for ((), event) in events.iter() {
         // An error occured with the standard input.
-        if event.errored {
+        if event.has_errored() {
             panic!("error on {:?}", io::stdin());
         }
         // The standard input has data ready to be read.
-        if event.readable || event.hangup {
+        if event.is_readable() || event.has_hangup() {
             let mut buf = [0; 1024];
 
             // Read what we can from standard input and echo it.

--- a/examples/stdin.rs
+++ b/examples/stdin.rs
@@ -9,7 +9,7 @@ fn main() -> io::Result<()> {
     let mut events = popol::Events::with_capacity(1);
 
     // Register the program's standard input as a source of "read" readiness events.
-    sources.register((), &io::stdin(), popol::interest::READ);
+    sources.register((), &io::stdin(), popol::event::READ);
 
     // Wait on our event sources for at most 6 seconds. If an event source is
     // ready before then, process its events. Otherwise, timeout.

--- a/examples/tcp-listener.rs
+++ b/examples/tcp-listener.rs
@@ -32,11 +32,11 @@ fn main() -> io::Result<()> {
 
         for (key, event) in events.iter() {
             match key {
-                Source::Peer(addr) if event.readable => {
+                Source::Peer(addr) if event.is_readable() => {
                     // Peer socket has data to be read.
                     println!("{} is readable", addr);
                 }
-                Source::Peer(addr) if event.writable => {
+                Source::Peer(addr) if event.is_writable() => {
                     // Peer socket is ready to be written.
                     println!("{} is writable", addr);
                 }

--- a/examples/tcp-listener.rs
+++ b/examples/tcp-listener.rs
@@ -25,7 +25,7 @@ fn main() -> io::Result<()> {
     listener.set_nonblocking(true)?;
 
     // Register the listener socket, using the corresponding identifier.
-    sources.register(Source::Listener, &listener, popol::interest::READ);
+    sources.register(Source::Listener, &listener, popol::event::READ);
 
     loop {
         sources.poll(&mut events, Timeout::Never)?;
@@ -53,7 +53,7 @@ fn main() -> io::Result<()> {
                     conn.set_nonblocking(true)?;
 
                     // Register the new peer using the `Peer` variant of `Source`.
-                    sources.register(Source::Peer(addr), &conn, popol::interest::ALL);
+                    sources.register(Source::Peer(addr), &conn, popol::event::ALL);
                     // Save the connection to make sure it isn't dropped.
                     peers.insert(addr, conn);
                 },

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -16,7 +16,7 @@ fn main() -> io::Result<()> {
         sources.poll(&mut events, Timeout::Never)?;
 
         for (addr, event) in events.iter() {
-            if event.readable {
+            if event.is_readable() {
                 let mut buf = [0; 32];
 
                 match stream.read(&mut buf[..]) {

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -10,7 +10,7 @@ fn main() -> io::Result<()> {
     let mut sources = Sources::new();
 
     stream.set_nonblocking(true)?;
-    sources.register(stream.peer_addr()?, &stream, popol::interest::READ);
+    sources.register(stream.peer_addr()?, &stream, popol::event::READ);
 
     loop {
         sources.poll(&mut events, Timeout::Never)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!             // Read what we can from standard input and echo it.
 //!             match io::stdin().read(&mut buf[..]) {
 //!                 Ok(n) => io::stdout().write_all(&buf[..n])?,
-//!                 Err(err) => panic!(err),
+//!                 Err(err) => panic!("{}", err),
 //!             }
 //!         }
 //!     }


### PR DESCRIPTION
`Source` is a `Copy` type. `Event` type was providing accessors to its values by holding references. This was making API polluted with lifetimes and types which are hard to distinguish.

This PR simplifies type system to just one type, `Event`, which is a `Copy` type requiring no lifetimes