### PR TITLE
Expose fired events via method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,11 @@ impl Source {
         self.events &= !events;
     }
 
+    /// Returns raw representation of events which fired during poll.
+    pub fn fired_events(&self) -> PollEvents {
+        self.revents
+    }
+
     /// The source is writable.
     pub fn is_writable(self) -> bool {
         self.revents & interest::WRITE != 0


### PR DESCRIPTION
This allows to access all events which has fired for a resource in case of an error and make them a part of error reporting, like it is done here:

https://github.com/rust-amplify/io-reactor/blob/f8f1ebb7e54edc897e59a440291210bdd7752acf/src/poller/popol.rs#L89-L90
