### PR TITLE
Prevent test_timeout from failing when a key is pressed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -677,10 +677,12 @@ mod tests {
 
     #[test]
     fn test_timeout() -> io::Result<()> {
+        let (_writer, reader) = UnixStream::pair()?;
+
         let mut events = Vec::new();
         let mut sources = Sources::new();
 
-        sources.register((), &io::stdout(), interest::READ);
+        sources.register((), &reader, interest::READ);
 
         let err = sources
             .poll(&mut events, Timeout::from_millis(1))


### PR DESCRIPTION
`test_timeout()` checks that the timeout parameter works by waiting on stdout to be ready for reading with a timeout of 1 ms. One might guess that stdout would never be ready for reading, but it appears that on macOS, at least, pressing enter while running the tests will cause stdout to be ready for reading, which in turn will cause the test to fail.

This switches `test_timeout()` to use `UnixStream::pair()` and just never write to the writer. This works even when keys are pressed while the tests are running.

---

Just got to say, stdout being ready for reading is super weird.