### PR TITLE
Fix race condition in `test_threaded`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -716,7 +716,6 @@ mod tests {
 
             for writer in &mut [&writer1, &writer2, &writer0] {
                 writer.write_all(&[1]).unwrap();
-                writer.write_all(&[2]).unwrap();
             }
         });
 
@@ -743,8 +742,8 @@ mod tests {
                 };
                 let n = reader.read(&mut buf[..])?;
 
-                assert_eq!(n, 2);
-                assert_eq!(&buf[..], &[1, 2]);
+                assert_eq!(n, 1);
+                assert_eq!(&buf[..], &[1, 0]);
             }
         }
         handle.join().unwrap();


### PR DESCRIPTION
Previously, `test_threaded()` started a thread that made two writes to each pipe. This had the potential for a race condition since the read might occur between the two writes. This changes it to make only one write for each pipe.

This maintains the two byte buffer despite reading only one byte just to confirm that it never somehow reads too much.

An alternate solution would be to fill buffers for each of the pipes and wait until they closed to check what was read. I thought that would be significantly more complicated.

I observed the race condition under Linux on Rust 1.71.0.